### PR TITLE
Add support for CloudWatch alarm actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ module "postgresql_rds" {
 
   private_subnet_ids = "subnet-4a887f3c,subnet-76dae35d"
   parameter_group_family = "postgres9.4"
+
+  alarm_actions = "arn:aws:sns..."
 }
 ```
 
@@ -52,6 +54,7 @@ module "postgresql_rds" {
 - `private_subnet_ids` - Comma delimited list of private subnet IDs
 - `parameter_group_family` - Database engine parameter group family (default:
   `postgres9.4`)
+- `alarm_actions` - Comma delimited list of ARNs to be notified via CloudWatch
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -92,6 +92,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu" {
   dimensions {
     DBInstanceIdentifier = "${aws_db_instance.postgresql.name}"
   }
+  alarm_actions = ["${split(",", var.alarm_actions)}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "disk_queue" {
@@ -107,6 +108,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue" {
   dimensions {
     DBInstanceIdentifier = "${aws_db_instance.postgresql.name}"
   }
+  alarm_actions = ["${split(",", var.alarm_actions)}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "disk_free" {
@@ -123,6 +125,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_free" {
   dimensions {
     DBInstanceIdentifier = "${aws_db_instance.postgresql.name}"
   }
+  alarm_actions = ["${split(",", var.alarm_actions)}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_free" {
@@ -134,9 +137,10 @@ resource "aws_cloudwatch_metric_alarm" "memory_free" {
   namespace = "AWS/RDS"
   period = "60"
   statistic = "Average"
-  # 12MB in bytes
+  # 128MB in bytes
   threshold = "128000000"
   dimensions {
     DBInstanceIdentifier = "${aws_db_instance.postgresql.name}"
   }
+  alarm_actions = ["${split(",", var.alarm_actions)}"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -39,3 +39,5 @@ variable "private_subnet_ids" { }
 variable "parameter_group_family" {
   default = "postgres9.4"
 }
+
+variable "alarm_actions" { }


### PR DESCRIPTION
Add ability to supply a list of ARNs to be notified once a CloudWatch alarm associated with RDS resources is triggered.

Attempts to resolve https://github.com/azavea/terraform-aws-postgresql-rds/issues/5.
