### PR TITLE
Add ID to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,5 @@ module "postgresql_rds" {
 
 - `hostname` - Public DNS name of database instance
 - `port` - Port of database instance
-- `endpoint` - Public DNS name and post separated by a `:`
+- `endpoint` - Public DNS name and port separated by a `:`
+- `id` - The database instance ID

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,7 @@ output "port" {
 output "endpoint" {
   value = "${aws_db_instance.postgresql.endpoint}"
 }
+
+output "id" {
+  value = "${aws_db_instance.postgresql.id}"
+}


### PR DESCRIPTION
This is so we can add cloudwatch alarms on RDS instances outside of the module.
