### PR TITLE
Remove security group rules; break backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ module "postgresql_rds" {
 
 ## Outputs
 
+- `id` - The database instance ID
+- `database_security_group_id` - Security group ID of the database
 - `hostname` - Public DNS name of database instance
 - `port` - Port of database instance
 - `endpoint` - Public DNS name and port separated by a `:`
-- `id` - The database instance ID

--- a/main.tf
+++ b/main.tf
@@ -5,23 +5,29 @@
 resource "aws_security_group" "postgresql" {
   vpc_id = "${var.vpc_id}"
 
-  ingress {
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
-  }
-
-  egress {
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
-  }
-
   tags {
     Name = "sgDatabaseServer"
   }
+}
+
+resource "aws_security_group_rule" "postgresql_ingress" {
+    type = "ingress"
+    from_port = 5432
+    to_port = 5432
+    protocol = "tcp"
+    cidr_blocks = ["${var.vpc_cidr_block}"]
+
+    security_group_id = "${aws_security_group.postgresql.id}"
+}
+
+resource "aws_security_group_rule" "postgresql_egress" {
+    type = "egress"
+    from_port = 5432
+    to_port = 5432
+    protocol = "tcp"
+    cidr_blocks = ["${var.vpc_cidr_block}"]
+
+    security_group_id = "${aws_security_group.postgresql.id}"
 }
 
 #

--- a/main.tf
+++ b/main.tf
@@ -10,26 +10,6 @@ resource "aws_security_group" "postgresql" {
   }
 }
 
-resource "aws_security_group_rule" "postgresql_ingress" {
-    type = "ingress"
-    from_port = 5432
-    to_port = 5432
-    protocol = "tcp"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
-
-    security_group_id = "${aws_security_group.postgresql.id}"
-}
-
-resource "aws_security_group_rule" "postgresql_egress" {
-    type = "egress"
-    from_port = 5432
-    to_port = 5432
-    protocol = "tcp"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
-
-    security_group_id = "${aws_security_group.postgresql.id}"
-}
-
 #
 # RDS resources
 #

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,11 @@
+output "id" {
+  value = "${aws_db_instance.postgresql.id}"
+}
+
+output "database_security_group_id" {
+  value = "${aws_security_group.postgresql.id}"
+}
+
 output "hostname" {
   value = "${aws_db_instance.postgresql.address}"
 }
@@ -8,8 +16,4 @@ output "port" {
 
 output "endpoint" {
   value = "${aws_db_instance.postgresql.endpoint}"
-}
-
-output "id" {
-  value = "${aws_db_instance.postgresql.id}"
 }


### PR DESCRIPTION
The `aws_security_group_rule` resources are being removed. This will push more responsibility around accessing the RDS instance to the Terraform module consumer, but hopefully increases the module's overall flexibility.

---

**Testing**

I used a Terraform file like this one to test:

``` hcl
provider "aws" {
  region = "us-east-1"
}

module "vpc" {
  source = "github.com/azavea/terraform-aws-vpc?ref=0.4.0"

  name                       = "Default"
  region                     = "us-east-1"
  key_name                   = "joker"
  cidr_block                 = "10.0.0.0/16"
  external_access_cidr_block = "0.0.0.0/0"
  private_subnet_cidr_blocks = "10.0.1.0/24,10.0.3.0/24"
  public_subnet_cidr_blocks  = "10.0.0.0/24,10.0.2.0/24"
  availability_zones         = "us-east-1c,us-east-1d"
  bastion_ami                = "ami-ff02509a"
  bastion_instance_type      = "t2.nano"
}

module "postgresql_rds" {
  source = "/Users/hcastro/Projects/terraform-aws-postgresql-rds"

  vpc_id = "${module.vpc.id}"
  vpc_cidr_block = "${module.vpc.cidr_block}"

  allocated_storage = "32"
  engine_version = "9.4.4"
  instance_type = "db.t2.micro"
  storage_type = "gp2"
  database_name = "hector"
  database_username = "hector"
  database_password = "secret"
  backup_retention_period = "30"
  backup_window = "04:00-04:30"
  maintenance_window = "sun:04:30-sun:05:30"
  multi_availability_zone = false
  storage_encrypted = false

  private_subnet_ids = "${module.vpc.private_subnet_ids}"

  parameter_group_family = "postgres9.4"

  alarm_actions = "arn:aws:sns:us-east-1:715496170458:NotifyMe"

}
```
