### PR TITLE
Remove security, subnet, and parameter groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ module "postgresql_rds" {
   source = "github.com/azavea/terraform-aws-postgresql-rds"
 
   vpc_id = "vpc-20f74844"
-  vpc_cidr_block = "10.0.0.0/16"
 
   allocated_storage = "32"
   engine_version = "9.4.4"
   instance_type = "db.t2.micro"
   storage_type = "gp2"
+  database_identifier = "jl23kj32sdf"
   database_name = "hector"
   database_username = "hector"
   database_password = "secret"
@@ -24,11 +24,15 @@ module "postgresql_rds" {
   auto_minor_version_upgrade = false
   multi_availability_zone = true
   storage_encrypted = false
+  subnet_group = "${aws_db_subnet_group.default.name}"
+  parameter_group = "${aws_db_parameter_group.default.name}"
 
-  private_subnet_ids = "subnet-4a887f3c,subnet-76dae35d"
-  parameter_group_family = "postgres9.4"
-
+  alarm_cpu_threshold = 75
+  alarm_disk_queue_threshold = 10
+  alarm_free_disk_threshold = 5000000000
+  alarm_free_memory_threshold = 128000000
   alarm_actions = "arn:aws:sns..."
+
   project = "Something"
   environment = "Staging"
 }
@@ -39,11 +43,11 @@ module "postgresql_rds" {
 - `project` - Name of project this VPC is meant to house (default: `Unknown`)
 - `environment` - Name of environment this VPC is targeting (default: `Unknown`)
 - `vpc_id` - ID of VPC meant to house database
-- `vpc_cidr_block` - CIDR block of VPC
 - `allocated_storage` - Storage allocated to database instance (default: `32`)
 - `engine_version` - Database engine version (default: `9.4.4`)
 - `instance_type` - Instance type for database instance (default: `db.t2.micro`)
 - `storage_type` - Type of underlying storage for database (default: `gp2`)
+- `database_identifier` - Identifier for RDS instance
 - `database_name` - Name of database inside storage engine
 - `database_username` - Name of user inside storage engine
 - `database_password` - Database password inside storage engine
@@ -58,9 +62,13 @@ module "postgresql_rds" {
 - `multi_availability_zone` - Flag to enable hot standby in another availability
   zone (default: `false`)
 - `storage_encrypted` - Flag to enable storage encryption (default: `false`)
-- `private_subnet_ids` - Comma delimited list of private subnet IDs
-- `parameter_group_family` - Database engine parameter group family (default:
-  `postgres9.4`)
+- `subnet_group` - Database subnet group
+- `parameter_group` - Database engine parameter group (default:
+  `default.postgres9.4`)
+- `alarm_cpu_threshold` - CPU alarm threshold as a percentage (default: `75`)
+- `alarm_disk_queue_threshold` - Disk queue alarm threshold (default: `10`)
+- `alarm_free_disk_threshold` - Free disk alarm threshold in bytes (default: `5000000000`)
+- `alarm_free_memory_threshold` - Free memory alarm threshold in bytes (default: `128000000`)
 - `alarm_actions` - Comma delimited list of ARNs to be notified via CloudWatch
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ module "postgresql_rds" {
 
 ## Outputs
 
+- `id` - The database instance ID
+- `database_security_group_id` - Security group ID of the database
 - `hostname` - Public DNS name of database instance
 - `port` - Port of database instance
 - `endpoint` - Public DNS name and port separated by a `:`
-- `id` - The database instance ID

--- a/README.md
+++ b/README.md
@@ -29,11 +29,15 @@ module "postgresql_rds" {
   parameter_group_family = "postgres9.4"
 
   alarm_actions = "arn:aws:sns..."
+  project = "Something"
+  environment = "Staging"
 }
 ```
 
 ## Variables
 
+- `project` - Name of project this VPC is meant to house (default: `Unknown`)
+- `environment` - Name of environment this VPC is targeting (default: `Unknown`)
 - `vpc_id` - ID of VPC meant to house database
 - `vpc_cidr_block` - CIDR block of VPC
 - `allocated_storage` - Storage allocated to database instance (default: `32`)

--- a/main.tf
+++ b/main.tf
@@ -17,49 +17,29 @@ resource "aws_security_group" "postgresql" {
 #
 
 resource "aws_db_instance" "postgresql" {
-  allocated_storage          = "${var.allocated_storage}"
-  engine                     = "postgres"
-  engine_version             = "${var.engine_version}"
-  identifier                 = "${var.database_name}"
-  instance_class             = "${var.instance_type}"
-  storage_type               = "${var.storage_type}"
-  name                       = "${var.database_name}"
-  password                   = "${var.database_password}"
-  username                   = "${var.database_username}"
-  backup_retention_period    = "${var.backup_retention_period}"
-  backup_window              = "${var.backup_window}"
-  maintenance_window         = "${var.maintenance_window}"
-  auto_minor_version_upgrade = "${var.auto_minor_version_upgrade}"
-  multi_az                   = "${var.multi_availability_zone}"
-  port                       = "5432"
-  vpc_security_group_ids     = ["${aws_security_group.postgresql.id}"]
-  db_subnet_group_name       = "${aws_db_subnet_group.default.name}"
-  parameter_group_name       = "${aws_db_parameter_group.default.name}"
-  storage_encrypted          = "${var.storage_encrypted}"
+  allocated_storage       = "${var.allocated_storage}"
+  engine                  = "postgres"
+  engine_version          = "${var.engine_version}"
+  identifier              = "${var.database_identifier}"
+  instance_class          = "${var.instance_type}"
+  storage_type            = "${var.storage_type}"
+  name                    = "${var.database_name}"
+  password                = "${var.database_password}"
+  username                = "${var.database_username}"
+  backup_retention_period = "${var.backup_retention_period}"
+  backup_window           = "${var.backup_window}"
+  maintenance_window      = "${var.maintenance_window}"
+  multi_az                = "${var.multi_availability_zone}"
+  port                    = "5432"
+  vpc_security_group_ids  = ["${aws_security_group.postgresql.id}"]
+  db_subnet_group_name    = "${var.subnet_group}"
+  parameter_group_name    = "${var.parameter_group}"
+  storage_encrypted       = "${var.storage_encrypted}"
 
   tags {
-    Name = "DatabaseServer"
-  }
-}
-
-resource "aws_db_subnet_group" "default" {
-  name        = "${var.database_name}-subnet-group"
-  description = "Private subnets for the RDS instances"
-  subnet_ids  = ["${split(",", var.private_subnet_ids)}"]
-
-  tags {
-    Name = "dbsngDatabaseServer"
-  }
-}
-
-resource "aws_db_parameter_group" "default" {
-  name        = "${var.database_name}-parameter-group"
-  description = "Parameter group for the RDS instances"
-  family      = "${var.parameter_group_family}"
-
-  parameter {
-    name  = "log_min_duration_statement"
-    value = "500"
+    Name        = "DatabaseServer"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
   }
 }
 
@@ -67,8 +47,8 @@ resource "aws_db_parameter_group" "default" {
 # CloudWatch resources
 #
 
-resource "aws_cloudwatch_metric_alarm" "cpu" {
-  alarm_name          = "alarmDatabaseServerCPUUtilization-${var.database_name}"
+resource "aws_cloudwatch_metric_alarm" "database_cpu" {
+  alarm_name          = "alarm${var.environment}DatabaseServerCPUUtilization"
   alarm_description   = "Database server CPU utilization"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
@@ -76,7 +56,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu" {
   namespace           = "AWS/RDS"
   period              = "300"
   statistic           = "Average"
-  threshold           = "75"
+  threshold           = "${var.alarm_cpu_threshold}"
 
   dimensions {
     DBInstanceIdentifier = "${aws_db_instance.postgresql.id}"
@@ -85,8 +65,8 @@ resource "aws_cloudwatch_metric_alarm" "cpu" {
   alarm_actions = ["${split(",", var.alarm_actions)}"]
 }
 
-resource "aws_cloudwatch_metric_alarm" "disk_queue" {
-  alarm_name          = "alarmDatabaseServerDiskQueueDepth-${var.database_name}"
+resource "aws_cloudwatch_metric_alarm" "database_disk_queue" {
+  alarm_name          = "alarm${var.environment}DatabaseServerDiskQueueDepth"
   alarm_description   = "Database server disk queue depth"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
@@ -94,7 +74,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue" {
   namespace           = "AWS/RDS"
   period              = "60"
   statistic           = "Average"
-  threshold           = "10"
+  threshold           = "${var.alarm_disk_queue_threshold}"
 
   dimensions {
     DBInstanceIdentifier = "${aws_db_instance.postgresql.id}"
@@ -103,8 +83,8 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue" {
   alarm_actions = ["${split(",", var.alarm_actions)}"]
 }
 
-resource "aws_cloudwatch_metric_alarm" "disk_free" {
-  alarm_name          = "alarmDatabaseServerFreeStorageSpace-${var.database_name}"
+resource "aws_cloudwatch_metric_alarm" "database_disk_free" {
+  alarm_name          = "alarm${var.environment}DatabaseServerFreeStorageSpace"
   alarm_description   = "Database server free storage space"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
@@ -112,9 +92,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_free" {
   namespace           = "AWS/RDS"
   period              = "60"
   statistic           = "Average"
-
-  # 5GB in bytes
-  threshold = "5000000000"
+  threshold           = "${var.alarm_free_disk_threshold}"
 
   dimensions {
     DBInstanceIdentifier = "${aws_db_instance.postgresql.id}"
@@ -123,8 +101,8 @@ resource "aws_cloudwatch_metric_alarm" "disk_free" {
   alarm_actions = ["${split(",", var.alarm_actions)}"]
 }
 
-resource "aws_cloudwatch_metric_alarm" "memory_free" {
-  alarm_name          = "alarmDatabaseServerFreeableMemory-${var.database_name}"
+resource "aws_cloudwatch_metric_alarm" "database_memory_free" {
+  alarm_name          = "alarm${var.environment}DatabaseServerFreeableMemory"
   alarm_description   = "Database server freeable memory"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
@@ -132,15 +110,10 @@ resource "aws_cloudwatch_metric_alarm" "memory_free" {
   namespace           = "AWS/RDS"
   period              = "60"
   statistic           = "Average"
-
-  # 128MB in bytes
-  threshold = "128000000"
+  threshold           = "${var.alarm_free_memory_threshold}"
 
   dimensions {
     DBInstanceIdentifier = "${aws_db_instance.postgresql.id}"
-    Name        = "DatabaseServer"
-    Project     = "${var.project}"
-    Environment = "${var.environment}"
   }
 
   alarm_actions = ["${split(",", var.alarm_actions)}"]

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,9 @@ resource "aws_security_group" "postgresql" {
   vpc_id = "${var.vpc_id}"
 
   tags {
-    Name = "sgDatabaseServer"
+    Name        = "sgDatabaseServer"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
   }
 }
 
@@ -136,6 +138,9 @@ resource "aws_cloudwatch_metric_alarm" "memory_free" {
 
   dimensions {
     DBInstanceIdentifier = "${aws_db_instance.postgresql.id}"
+    Name        = "DatabaseServer"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
   }
 
   alarm_actions = ["${split(",", var.alarm_actions)}"]

--- a/main.tf
+++ b/main.tf
@@ -5,20 +5,6 @@
 resource "aws_security_group" "postgresql" {
   vpc_id = "${var.vpc_id}"
 
-  ingress {
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
-  }
-
-  egress {
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
-  }
-
   tags {
     Name = "sgDatabaseServer"
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,11 @@
+output "id" {
+  value = "${aws_db_instance.postgresql.id}"
+}
+
+output "database_security_group_id" {
+  value = "${aws_security_group.postgresql.id}"
+}
+
 output "hostname" {
   value = "${aws_db_instance.postgresql.address}"
 }
@@ -8,8 +16,4 @@ output "port" {
 
 output "endpoint" {
   value = "${aws_db_instance.postgresql.endpoint}"
-}
-
-output "id" {
-  value = "${aws_db_instance.postgresql.id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,11 @@
+variable "project" {
+  default = "Unknown"
+}
+
+variable "environment" {
+  default = "Unknown"
+}
+
 variable "vpc_id" {}
 
 variable "vpc_cidr_block" {}

--- a/variables.tf
+++ b/variables.tf
@@ -1,15 +1,13 @@
-variable "vpc_id" {
-}
+variable "vpc_id" {}
 
-variable "vpc_cidr_block" {
-}
+variable "vpc_cidr_block" {}
 
 variable "allocated_storage" {
   default = "32"
 }
 
 variable "engine_version" {
-  default = "9.4.4"
+  default = "9.5.2"
 }
 
 variable "instance_type" {
@@ -20,14 +18,11 @@ variable "storage_type" {
   default = "gp2"
 }
 
-variable "database_name" {
-}
+variable "database_name" {}
 
-variable "database_password" {
-}
+variable "database_password" {}
 
-variable "database_username" {
-}
+variable "database_username" {}
 
 variable "backup_retention_period" {
   default = "30"
@@ -55,12 +50,10 @@ variable "storage_encrypted" {
   default = false
 }
 
-variable "private_subnet_ids" {
-}
+variable "private_subnet_ids" {}
 
 variable "parameter_group_family" {
-  default = "postgres9.4"
+  default = "postgres9.5"
 }
 
-variable "alarm_actions" {
-}
+variable "alarm_actions" {}

--- a/variables.tf
+++ b/variables.tf
@@ -8,8 +8,6 @@ variable "environment" {
 
 variable "vpc_id" {}
 
-variable "vpc_cidr_block" {}
-
 variable "allocated_storage" {
   default = "32"
 }
@@ -25,6 +23,8 @@ variable "instance_type" {
 variable "storage_type" {
   default = "gp2"
 }
+
+variable "database_identifier" {}
 
 variable "database_name" {}
 
@@ -58,10 +58,28 @@ variable "storage_encrypted" {
   default = false
 }
 
-variable "private_subnet_ids" {}
+variable "subnet_group" {}
 
-variable "parameter_group_family" {
-  default = "postgres9.5"
+variable "parameter_group" {
+  default = "default.postgres9.4"
+}
+
+variable "alarm_cpu_threshold" {
+  default = 75
+}
+
+variable "alarm_disk_queue_threshold" {
+  default = 10
+}
+
+variable "alarm_free_disk_threshold" {
+  # 5GB
+  default = 5000000000
+}
+
+variable "alarm_free_memory_threshold" {
+  # 128MB
+  default = 128000000
 }
 
 variable "alarm_actions" {}


### PR DESCRIPTION
Instead of defining security, RDS subnet, and parameter groups, emit the necessary IDs so that the module consumer can specify their own customized resources.

Also, add two top level module attributes `project` and `environment`. These variables are used to add tags to all AWS resources that support them.

---

**Testing**

The easiest way to test this is probably to test https://github.com/azavea/pwd-stormdrain-marking/pull/41.
