### PR TITLE
Add support for creating final snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ module "postgresql_rds" {
   (default: `sun:04:30-sun:05:30`)
 - `auto_minor_version_upgrade` - Minor engine upgrades are applied automatically
  to the DB instance during the maintenance window (default: `true`)
+- `final_snapshot_identifier` - Identifier for final snapshot if `skip_final_snapshot` is set to `false` (default: `terraform-aws-postgresql-rds-snapshot`)
+- `skip_final_snapshot` - Flag to enable or disable a snapshot if the database instance is terminated (default: `true`)
+- `copy_tags_to_snapshot` - Flag to enable or disable copying instance tags to the final snapshot (default: `false`)
 - `multi_availability_zone` - Flag to enable hot standby in another availability
   zone (default: `false`)
 - `storage_encrypted` - Flag to enable storage encryption (default: `false`)

--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,9 @@ resource "aws_db_instance" "postgresql" {
   backup_window              = "${var.backup_window}"
   maintenance_window         = "${var.maintenance_window}"
   auto_minor_version_upgrade = "${var.auto_minor_version_upgrade}"
+  final_snapshot_identifier  = "${var.final_snapshot_identifier}"
+  skip_final_snapshot        = "${var.skip_final_snapshot}"
+  copy_tags_to_snapshot      = "${var.copy_tags_to_snapshot}"
   multi_az                   = "${var.multi_availability_zone}"
   port                       = "${var.database_port}"
   vpc_security_group_ids     = ["${aws_security_group.postgresql.id}"]

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,18 @@ variable "auto_minor_version_upgrade" {
   default = true
 }
 
+variable "final_snapshot_identifier" {
+  default = "terraform-aws-postgresql-rds-snapshot"
+}
+
+variable "skip_final_snapshot" {
+  default = true
+}
+
+variable "copy_tags_to_snapshot" {
+  default = false
+}
+
 variable "multi_availability_zone" {
   default = false
 }


### PR DESCRIPTION
If the RDS instance is terminated, add support for taking a final snapshot of its contents, naming it, and copying existing tags to it.

Builds on top of #19 
Resolves #18 

A side-effect of giving `final_snapshot_identifier` a default value is that even if you change no module variables, it'll mark that attribute as changed:

```
~ module.database.aws_db_instance.postgresql
    final_snapshot_identifier: "" => "terraform-aws-postgresql-rds-snapshot"


Plan: 0 to add, 1 to change, 0 to destroy.
```

Leaving the attribute set to `"`" leads to an error, and there is no way to easily leave just that attribute unset completely. I think that the inclusion of this feature in a release would require bumping at least the minor version.