### PR TITLE
Allow configurations of more actions on alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ module "postgresql_rds" {
 - `alarm_disk_queue_threshold` - Disk queue alarm threshold (default: `10`)
 - `alarm_free_disk_threshold` - Free disk alarm threshold in bytes (default: `5000000000`)
 - `alarm_free_memory_threshold` - Free memory alarm threshold in bytes (default: `128000000`)
-- `alarm_actions` - List of ARNs to be notified via CloudWatch
+- `alarm_actions` - List of ARNs to be notified via CloudWatch when alarm enters ALARM state
+- `ok_actions` - List of ARNs to be notified via CloudWatch when alarm enters OK state
+- `insufficient_data_actions` - List of ARNs to be notified via CloudWatch when alarm enters INSUFFICIENT_DATA state
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,8 @@ resource "aws_cloudwatch_metric_alarm" "database_cpu" {
   }
 
   alarm_actions = ["${var.alarm_actions}"]
+  ok_actions = ["${var.ok_actions}"]
+  insufficient_data_actions = ["${var.insufficient_data_actions}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "database_disk_queue" {
@@ -85,6 +87,8 @@ resource "aws_cloudwatch_metric_alarm" "database_disk_queue" {
   }
 
   alarm_actions = ["${var.alarm_actions}"]
+  ok_actions = ["${var.ok_actions}"]
+  insufficient_data_actions = ["${var.insufficient_data_actions}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "database_disk_free" {
@@ -103,6 +107,8 @@ resource "aws_cloudwatch_metric_alarm" "database_disk_free" {
   }
 
   alarm_actions = ["${var.alarm_actions}"]
+  ok_actions = ["${var.ok_actions}"]
+  insufficient_data_actions = ["${var.insufficient_data_actions}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "database_memory_free" {
@@ -121,4 +127,6 @@ resource "aws_cloudwatch_metric_alarm" "database_memory_free" {
   }
 
   alarm_actions = ["${var.alarm_actions}"]
+  ok_actions = ["${var.ok_actions}"]
+  insufficient_data_actions = ["${var.insufficient_data_actions}"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -101,3 +101,11 @@ variable "alarm_free_memory_threshold" {
 variable "alarm_actions" {
   type = "list"
 }
+
+variable "ok_actions" {
+  type = "list"
+}
+
+variable "insufficient_data_actions" {
+  type = "list"
+}


### PR DESCRIPTION
OpsGenie integration works better when the Cloudwatch alarms also sends OK and INSUFFICIENT_DATA messages. I added these to the setup (`ok_actions` and `insufficient_data_actions`) in the same way that `alarm_actions` was setup