### PR TITLE
Alerts with several databases

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_db_instance" "postgresql" {
 #
 
 resource "aws_cloudwatch_metric_alarm" "database_cpu" {
-  alarm_name          = "alarm-${var.environment}-${var.database_identifier}_DatabaseServerCPUUtilization"
+  alarm_name          = "alarm${var.environment}DatabaseServerCPUUtilization-${var.database_identifier}"
   alarm_description   = "Database server CPU utilization"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
@@ -72,7 +72,7 @@ resource "aws_cloudwatch_metric_alarm" "database_cpu" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "database_disk_queue" {
-  alarm_name          = "alarm_${var.environment}_${var.database_identifier}_DatabaseServerDiskQueueDepth"
+  alarm_name          = "alarm${var.environment}DatabaseServerDiskQueueDepth-${var.database_identifier}"
   alarm_description   = "Database server disk queue depth"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
@@ -92,7 +92,7 @@ resource "aws_cloudwatch_metric_alarm" "database_disk_queue" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "database_disk_free" {
-  alarm_name          = "alarm_${var.environment}_${var.database_identifier}_DatabaseServerFreeStorageSpace"
+  alarm_name          = "alarm${var.environment}DatabaseServerFreeStorageSpace-${var.database_identifier}"
   alarm_description   = "Database server free storage space"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
@@ -112,7 +112,7 @@ resource "aws_cloudwatch_metric_alarm" "database_disk_free" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "database_memory_free" {
-  alarm_name          = "alarm_${var.environment}_${var.database_identifier}_DatabaseServerFreeableMemory"
+  alarm_name          = "alarm${var.environment}DatabaseServerFreeableMemory-${var.database_identifier}"
   alarm_description   = "Database server freeable memory"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"

--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_db_instance" "postgresql" {
 #
 
 resource "aws_cloudwatch_metric_alarm" "database_cpu" {
-  alarm_name          = "alarm${var.environment}DatabaseServerCPUUtilization"
+  alarm_name          = "alarm-${var.environment}-${var.database_identifier}_DatabaseServerCPUUtilization"
   alarm_description   = "Database server CPU utilization"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
@@ -72,7 +72,7 @@ resource "aws_cloudwatch_metric_alarm" "database_cpu" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "database_disk_queue" {
-  alarm_name          = "alarm${var.environment}DatabaseServerDiskQueueDepth"
+  alarm_name          = "alarm_${var.environment}_${var.database_identifier}_DatabaseServerDiskQueueDepth"
   alarm_description   = "Database server disk queue depth"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
@@ -92,7 +92,7 @@ resource "aws_cloudwatch_metric_alarm" "database_disk_queue" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "database_disk_free" {
-  alarm_name          = "alarm${var.environment}DatabaseServerFreeStorageSpace"
+  alarm_name          = "alarm_${var.environment}_${var.database_identifier}_DatabaseServerFreeStorageSpace"
   alarm_description   = "Database server free storage space"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
@@ -112,7 +112,7 @@ resource "aws_cloudwatch_metric_alarm" "database_disk_free" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "database_memory_free" {
-  alarm_name          = "alarm${var.environment}DatabaseServerFreeableMemory"
+  alarm_name          = "alarm_${var.environment}_${var.database_identifier}_DatabaseServerFreeableMemory"
   alarm_description   = "Database server freeable memory"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"


### PR DESCRIPTION
I had two databases with the same ${var.environment} set and made the two databases share alarms (with terraform flipping back and forth on each run which database the alarms were connected to)

This introduces the database identifier in the CW alarm name to make sure they are unique.