### PR TITLE
Allow database create from snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ module "postgresql_rds" {
 - `instance_type` - Instance type for database instance (default: `db.t2.micro`)
 - `storage_type` - Type of underlying storage for database (default: `gp2`)
 - `database_identifier` - Identifier for RDS instance
+- `snapshot_identifier` - The name of the snapshot (if any) the database should be created from
 - `database_name` - Name of database inside storage engine
 - `database_username` - Name of user inside storage engine
 - `database_password` - Database password inside storage engine

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ resource "aws_db_instance" "postgresql" {
   engine                     = "postgres"
   engine_version             = "${var.engine_version}"
   identifier                 = "${var.database_identifier}"
+  snapshot_identifier        = "${var.snapshot_identifier}"
   instance_class             = "${var.instance_type}"
   storage_type               = "${var.storage_type}"
   name                       = "${var.database_name}"

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,10 @@ variable "vpc_id" {}
 
 variable "database_identifier" {}
 
+variable "snapshot_identifier" {
+  default = ""
+}
+
 variable "database_name" {}
 
 variable "database_password" {}


### PR DESCRIPTION
This allows creating the database from a snapshot, very practical when restoring an RDS backup snapshot into a new instance. If the variable is not set, it behaves as previously.