### PR TITLE
T2 cpu credit balance alarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ module "postgresql_rds" {
 - `alarm_disk_queue_threshold` - Disk queue alarm threshold (default: `10`)
 - `alarm_free_disk_threshold` - Free disk alarm threshold in bytes (default: `5000000000`)
 - `alarm_free_memory_threshold` - Free memory alarm threshold in bytes (default: `128000000`)
+- `alarm_cpu_credit_balance_threshold` - CPU credit balance threshold (default: `30`). Only used for `db.t2.*` instance types
 - `alarm_actions` - List of ARNs to be notified via CloudWatch when alarm enters ALARM state
 - `ok_actions` - List of ARNs to be notified via CloudWatch when alarm enters OK state
 - `insufficient_data_actions` - List of ARNs to be notified via CloudWatch when alarm enters INSUFFICIENT_DATA state

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ module "postgresql_rds" {
 - `alarm_disk_queue_threshold` - Disk queue alarm threshold (default: `10`)
 - `alarm_free_disk_threshold` - Free disk alarm threshold in bytes (default: `5000000000`)
 - `alarm_free_memory_threshold` - Free memory alarm threshold in bytes (default: `128000000`)
-- `alarm_cpu_credit_balance_threshold` - CPU credit balance threshold (default: `30`). Only used for `db.t2.*` instance types
+- `alarm_cpu_credit_balance_threshold` - CPU credit balance threshold (default: `30`). Only used for `db.t*` instance types
 - `alarm_actions` - List of ARNs to be notified via CloudWatch when alarm enters ALARM state
 - `ok_actions` - List of ARNs to be notified via CloudWatch when alarm enters OK state
 - `insufficient_data_actions` - List of ARNs to be notified via CloudWatch when alarm enters INSUFFICIENT_DATA state

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,11 @@
 #
+# Terraform required version
+#
+terraform {
+  required_version = ">= 0.8.0"
+}
+
+#
 # Security group resources
 #
 
@@ -133,7 +140,7 @@ resource "aws_cloudwatch_metric_alarm" "database_memory_free" {
 
 resource "aws_cloudwatch_metric_alarm" "database_cpu_credits" {
   // This results in 1 if instance_type starts with "db.t", 0 otherwise.
-  count               = "${replace(replace(var.instance_type, "/^db\\.[^t].*/", "0"), "/^db\\.t.*$/", "1")}"
+  count               = "${substr(var.instance_type, 0, 3) == "db.t" ? 1 : 0}"
   alarm_name          = "alarm${var.environment}DatabaseCPUCreditBalance-${var.database_identifier}"
   alarm_description   = "Database CPU credit balance"
   comparison_operator = "LessThanThreshold"

--- a/main.tf
+++ b/main.tf
@@ -134,7 +134,7 @@ resource "aws_cloudwatch_metric_alarm" "database_memory_free" {
 resource "aws_cloudwatch_metric_alarm" "database_cpu_credits" {
   // This results in 1 if instance_type starts with "db.t", 0 otherwise.
   count               = "${replace(replace(var.instance_type, "/^db\\.[^t].*/", "0"), "/^db\\.t.*$/", "1")}"
-  alarm_name          = "alarm_${var.environment}_${var.database_identifier}_DatabaseCPUCreditBalance"
+  alarm_name          = "alarm${var.environment}DatabaseCPUCreditBalance-${var.database_identifier}"
   alarm_description   = "Database CPU credit balance"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"

--- a/main.tf
+++ b/main.tf
@@ -130,3 +130,25 @@ resource "aws_cloudwatch_metric_alarm" "database_memory_free" {
   ok_actions                = ["${var.ok_actions}"]
   insufficient_data_actions = ["${var.insufficient_data_actions}"]
 }
+
+resource "aws_cloudwatch_metric_alarm" "database_cpu_credits" {
+  // This results in 1 if instance_type starts with "db.t", 0 otherwise.
+  count               = "${replace(replace(var.instance_type, "/^db\\.[^t].*/", "0"), "/^db\\.t.*$/", "1")}"
+  alarm_name          = "alarm_${var.environment}_${var.database_identifier}_DatabaseCPUCreditBalance"
+  alarm_description   = "Database CPU credit balance"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUCreditBalance"
+  namespace           = "AWS/RDS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "${var.alarm_cpu_credit_balance_threshold}"
+
+  dimensions {
+    DBInstanceIdentifier = "${aws_db_instance.postgresql.id}"
+  }
+
+  alarm_actions             = ["${var.alarm_actions}"]
+  ok_actions                = ["${var.ok_actions}"]
+  insufficient_data_actions = ["${var.insufficient_data_actions}"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -98,6 +98,10 @@ variable "alarm_free_memory_threshold" {
   default = "128000000"
 }
 
+variable "alarm_cpu_credit_balance_threshold" {
+  default = "30"
+}
+
 variable "alarm_actions" {
   type = "list"
 }


### PR DESCRIPTION
This implements CPU credit balance alarms when the database is a burstable type. The if/else-like behavior looks a bit hairy. It is taken from https://blog.gruntwork.io/terraform-tips-tricks-loops-if-statements-and-gotchas-f739bbae55f9. The default value is the number of cpu credits (approximately) that a db.t2.micro has when it first starts up.

This is the last pull request I have to make (for now at least).