### PR TITLE
Add support for provisioned IOPS storage

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2015 Azavea Inc.
+   Copyright 2018 Azavea Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ module "postgresql_rds" {
 - `engine_version` - Database engine version (default: `9.4.4`)
 - `instance_type` - Instance type for database instance (default: `db.t2.micro`)
 - `storage_type` - Type of underlying storage for database (default: `gp2`)
+- `iops` - The amount of provisioned IOPS. Setting this implies a `storage_type` of `io1` (default: `0`)
 - `database_identifier` - Identifier for RDS instance
 - `snapshot_identifier` - The name of the snapshot (if any) the database should be created from
 - `database_name` - Name of database inside storage engine

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,7 @@ resource "aws_db_instance" "postgresql" {
   snapshot_identifier        = "${var.snapshot_identifier}"
   instance_class             = "${var.instance_type}"
   storage_type               = "${var.storage_type}"
+  iops                       = "${var.iops}"
   name                       = "${var.database_name}"
   password                   = "${var.database_password}"
   username                   = "${var.database_username}"

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,10 @@ variable "storage_type" {
   default = "gp2"
 }
 
+variable "iops" {
+  default = "0"
+}
+
 variable "vpc_id" {}
 
 variable "database_identifier" {}


### PR DESCRIPTION
We already allowed users to override the `aws_db_instance.storage_type` via `storage_type`, but in order to fully support setting `storage_type` to `io1` (PIOPS storage), the `iops` attribute was needed.

Fixes #28 

---

**Testing**

See: https://github.com/azavea/raster-foundry-deployment/pull/139