### PR TITLE
Add enhanced monitoring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ module "postgresql_rds" {
   storage_encrypted = false
   subnet_group = "${aws_db_subnet_group.default.name}"
   parameter_group = "${aws_db_parameter_group.default.name}"
+  monitoring_interval = "60"
 
   alarm_cpu_threshold = "75"
   alarm_disk_queue_threshold = "10"
@@ -69,6 +70,7 @@ module "postgresql_rds" {
 - `multi_availability_zone` - Flag to enable hot standby in another availability
   zone (default: `false`)
 - `storage_encrypted` - Flag to enable storage encryption (default: `false`)
+- `monitoring_interval` - The interval, in seconds, between points when Enhanced Monitoring metrics are collected (default: `0`)
 - `subnet_group` - Database subnet group
 - `parameter_group` - Database engine parameter group (default:
   `default.postgres9.4`)

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,10 @@ variable "storage_encrypted" {
   default = false
 }
 
+variable "monitoring_interval" {
+  default = "0"
+}
+
 variable "subnet_group" {}
 
 variable "parameter_group" {


### PR DESCRIPTION
First, create the IAM resources necessary to allow enhanced metrics to be publishing to CloudWatch by RDS on our behalf. Then, add a variable to support customization of the metric publishing interval.

---

**Testing**

See: https://github.com/azavea/raster-foundry-deployment/pull/146