### PR TITLE
Add support for instance deletion projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ module "postgresql_rds" {
   subnet_group = "${aws_db_subnet_group.default.name}"
   parameter_group = "${aws_db_parameter_group.default.name}"
   monitoring_interval = "60"
+  deletion_protection = true
 
   alarm_cpu_threshold = "75"
   alarm_disk_queue_threshold = "10"
@@ -83,6 +84,7 @@ If you're curious to know more, see the discussion within https://github.com/ter
   zone (default: `false`)
 - `storage_encrypted` - Flag to enable storage encryption (default: `false`)
 - `monitoring_interval` - The interval, in seconds, between points when Enhanced Monitoring metrics are collected (default: `0`)
+- `deletion_protection` - Flag to protect the database instance from deletion (default: `false`)
 - `subnet_group` - Database subnet group
 - `parameter_group` - Database engine parameter group (default:
   `default.postgres9.4`)

--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,7 @@ resource "aws_db_instance" "postgresql" {
   storage_encrypted          = "${var.storage_encrypted}"
   monitoring_interval        = "${var.monitoring_interval}"
   monitoring_role_arn        = "${var.monitoring_interval > 0 ? aws_iam_role.enhanced_monitoring.arn : ""}"
+  deletion_protection        = "${var.deletion_protection}"
 
   tags {
     Name        = "DatabaseServer"

--- a/variables.tf
+++ b/variables.tf
@@ -86,6 +86,10 @@ variable "monitoring_interval" {
   default = "0"
 }
 
+variable "deletion_protection" {
+  default = false
+}
+
 variable "subnet_group" {}
 
 variable "parameter_group" {


### PR DESCRIPTION
Add an option to prevent RDS instance deletion when enabled. The database instance cannot be deleted when this is set to `true`.

Fixes https://github.com/azavea/terraform-aws-postgresql-rds/issues/34

---

**Testing**

Please test with https://github.com/azavea/raster-foundry-deployment/pull/215.