### PR TITLE
Add max_allocated_storage param, and update some defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+
+- Add support for 'max_allocated_storage' parameter
+
 ## 3.0.0
 
 - Add support for Terraform 0.12; 0.12 is now the minimum supported version.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ module "postgresql_rds" {
   source = "github.com/azavea/terraform-aws-postgresql-rds"
   vpc_id = "vpc-20f74844"
   allocated_storage = "32"
-  engine_version = "9.4.4"
-  instance_type = "db.t2.micro"
-  storage_type = "gp2"
+  max_allocated_storage = "64"
+  engine_version = "14"
+  instance_type = "db.t3.micro"
+  storage_type = "gp3"
   database_identifier = "jl23kj32sdf"
   database_name = "hector"
   database_username = "hector"
@@ -62,10 +63,11 @@ If you're curious to know more, see the discussion within https://github.com/ter
 - `project` - Name of project this VPC is meant to house (default: `Unknown`)
 - `environment` - Name of environment this VPC is targeting (default: `Unknown`)
 - `allocated_storage` - Storage allocated to database instance (default: `32`)
-- `engine_version` - Database engine version (default: `11.5`)
+- `max_allocated_storage` - Maximum storage to use with storage auto-scaling. `0` disables storage auto-scaling (default: `0`)
+- `engine_version` - Database engine version (default: `14`)
 - `instance_type` - Instance type for database instance (default: `db.t3.micro`)
-- `storage_type` - Type of underlying storage for database (default: `gp2`)
-- `iops` - The amount of provisioned IOPS. Setting this implies a `storage_type` of `io1` (default: `0`)
+- `storage_type` - Type of underlying storage for database (default: `gp3`)
+- `iops` - The amount of provisioned IOPS. Works with `storage_type` of `io1` or `gp3`. `gp3` volumes below 400GB are locked at 3000 IOPS. (default: `3000`)
 - `database_identifier` - Identifier for RDS instance
 - `snapshot_identifier` - The name of the snapshot (if any) the database should be created from
 - `database_name` - Name of database inside storage engine

--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,7 @@ resource "aws_security_group" "postgresql" {
 #
 resource "aws_db_instance" "postgresql" {
   allocated_storage               = var.allocated_storage
+  max_allocated_storage           = var.max_allocated_storage
   engine                          = "postgres"
   engine_version                  = var.engine_version
   identifier                      = var.database_identifier

--- a/variables.tf
+++ b/variables.tf
@@ -16,8 +16,14 @@ variable "allocated_storage" {
   description = "Storage allocated to database instance"
 }
 
+variable "max_allocated_storage" {
+  default     = 0
+  type        = number
+  description = "Max storage for auto-allocation"
+}
+
 variable "engine_version" {
-  default     = "11.5"
+  default     = "14"
   type        = string
   description = "Database engine version"
 }
@@ -29,13 +35,13 @@ variable "instance_type" {
 }
 
 variable "storage_type" {
-  default     = "gp2"
+  default     = "gp3"
   type        = string
   description = "Type of underlying storage for database"
 }
 
 variable "iops" {
-  default     = 0
+  default     = 3000
   type        = number
   description = "The amount of provisioned IOPS"
 }


### PR DESCRIPTION
This adds the [`max_allocated_storage` parameter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#max_allocated_storage), and a variable to provide a value for it.  The default is `0`, i.e. no automatic storage scaling.

While I was in the variables file and README to add that, I also updated a few defaults to more modern values, including changing the default storage class to gp3.  It's cheaper and faster, so it makes sense as a default, though the relationship with the `iops` parameter is a bit complicated—above 400GB, you can pick how much you want, but below that there's a fixed value, 3000 IOPS.  The IOPS value will automatically get set to that, but if you don't have the parameter set, Terraform will register it as a change (3000 -> null).  I'm not sure if applying that would crash, throw an error and ignore the change, or what, because I didn't try.  But that's why the IOPS default is now 3000.

Resolves #40 